### PR TITLE
Add pip to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - ipywidgets>=0.6.0
   - requests
   - mkl
+  - pip
   - pip:
     - pymatsolver
     - discretize


### PR DESCRIPTION
conda now complains if `pip` is not added explicitly but used.